### PR TITLE
remove transitive dep on time crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ homepage = "https://github.com/frehberg/spa-rs"
 repository = "https://github.com/frehberg/spa-rs"
 
 [dependencies]
-chrono = "^0.4"
+chrono = {version="^0.4", default-features=false, features=["clock"]}


### PR DESCRIPTION
It keeps getting flagged with CVEs.

Setting default-features=false removes the default oldtime feature from chrono, which removes the time 0.1 reference.

refs: https://github.com/chronotope/chrono/issues/602