### PR TITLE
Improved UX on `std` targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,13 @@ documentation = "https://docs.rs/spa/"
 homepage = "https://github.com/frehberg/spa-rs"
 repository = "https://github.com/frehberg/spa-rs"
 
+[features]
+default = []
+std = ["thiserror"]
+
 [dependencies]
 chrono = { version = "^0.4", default-features = false }
+thiserror = { version = "1.0.49", optional = true }
+
+[dev-dependencies]
+thiserror = "1.0.49"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,11 @@ authors = ["Frank Rehberger <frehberg@gmail.com>"]
 description = "The Solar Position Algorithm module (SPA) for Rust calculates the sunrise-sunset and azimuth and zenith-angle for specific geo-position and time (UTC); for example for solar-panel-alignment or automotive."
 license = "Apache-2.0"
 edition = '2021'
-keywords = ["solar", "algorithm" , "azimuth", "zenith", "sunrise"]
+keywords = ["solar", "algorithm", "azimuth", "zenith", "sunrise"]
 
 documentation = "https://docs.rs/spa/"
 homepage = "https://github.com/frehberg/spa-rs"
 repository = "https://github.com/frehberg/spa-rs"
 
 [dependencies]
-chrono = {version="^0.4", default-features=false}
-
-
+chrono = { version = "^0.4", default-features = false }

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 The Solar Position Algorithm module (SPA) for Rust calculates the sunrise-sunset and azimuth and zenith-angle for
 specific geo-position and time (UTC); for example for solar-panel-alignment or automotive.
 
-## Calculating the Sunrise and Sunset 
+## Calculating the Sunrise and Sunset
 
-The following function is calculating the sunrise-sunset at geo-pos `lat/lon` at time `t` (UTC). 
+The following function is calculating the sunrise-sunset at geo-pos `lat/lon` at time `t` (UTC).
 
 The algorithm has been ported to Rust from [http://lexikon.astronomie.info/zeitgleichung/neu.html](https://web.archive.org/web/20170812034800/http://lexikon.astronomie.info/zeitgleichung/neu.html)
 Its accuracy is in the range of a few minutes.
@@ -15,7 +15,7 @@ Its accuracy is in the range of a few minutes.
  * `lat` - latitude in WGS84 system, ranging from -90.0 to 90.0.
  * `lon` - longitude in WGS84 system, ranging from -180.0 to 180.0
 
-The function returns a result of type `SunriseAndSet`. 
+The function returns a result of type `SunriseAndSet`.
 
 ```rust
 pub enum SunriseAndSet {
@@ -33,7 +33,7 @@ polar day, or midnight sun, occurs when the Sun stays above the horizon for more
 
 Since the atmosphere bends the rays of the Sun, the polar day is longer than the polar night,
 and the area that is affected by polar night is somewhat smaller than the area of midnight sun.
-The polar circle is located at a latitude between these two areas, at the latitude of 
+The polar circle is located at a latitude between these two areas, at the latitude of
 approximately 66.5 degrees. The function is approximating the atmospheric bend using a height
 of 0,833333 degrees.
 
@@ -60,7 +60,7 @@ The algorithm is accurate to within 0.5 minutes of arc for the year 1999 and fol
 * `lat` - latitude in WGS84 system, ranging from -90.0 to 90.0.
 * `lon` - longitude in WGS84 system, ranging from -180.0 to 180.0
 
-The function returns a result of type `SolarPos`. 
+The function returns a result of type `SolarPos`.
 
 ```rust
 pub struct SolarPos {
@@ -77,58 +77,23 @@ In case latitude or longitude are not in valid ranges, the function will return 
 pub fn solar_position<F: FloatOps>(utc: DateTime<Utc>, lat: f64, lon: f64) -> Result<SolarPos, SpaError> {..}
 ```
 
-## Platform specific Float Operations 
-The SPA library supports `std` and `no_std` target builds, but requires the implementation of the trigonometric 
-operations etc. as defined by the trait `FloatOps`
+## Platform specific Float Operations
+The SPA library supports both `std` and `no_std` target builds via the `FloatOps` trait:
 
 ```rust
 pub trait FloatOps {
     fn sin(x: f64) -> f64;
     fn cos(x: f64) -> f64;
     fn tan(x: f64) -> f64;
-
     fn asin(x: f64) -> f64;
     fn acos(x: f64) -> f64;
     fn atan(x: f64) -> f64;
     fn atan2(y: f64, x: f64) -> f64;
-
     fn trunc(x: f64) -> f64;
 }
 ```
 
-The example below illustrates the usage for 
-the `std` target build, but this example can be adapted using the no_std crate [libm](https://docs.rs/libm/0.2.7/libm/) implemenating
-the floating point operaitons for targets without specific hardware support.
-
-```rust
-
-use chrono::{TimeZone, Utc};
-use spa::{solar_position, sunrise_and_set, SolarPos, FloatOps, SunriseAndSet};
-
-
-// FloatOps for the std environment
-pub struct StdFloatOps;
-
-// FloatOps for the std environment, mapping directly onto f64 operations
-impl FloatOps for StdFloatOps {
-    fn sin(x: f64) -> f64 { x.sin() }    fn cos(x: f64) -> f64 { x.cos() }     fn tan(x: f64) -> f64 { x.tan() }
-    fn asin(x: f64) -> f64 { x.asin() }  fn acos(x: f64) -> f64 { x.acos() }   fn atan(x: f64) -> f64 { x.atan() }
-    fn atan2(y: f64, x: f64) -> f64 { y.atan2(x) }
-    fn trunc(x: f64) -> f64 { x.trunc() }
-}
-
-// main
-fn main() {
-    let dt = Utc.with_ymd_and_hms(2005, 9, 30, 12, 0, 0)
-        .single().unwrap();
-
-    // geo-pos near Frankfurt/Germany
-    let lat = 50.0;
-    let lon = 10.0;
-
-    let _solpos: SolarPos = solar_position::<StdFloatOps>(dt, lat, lon).unwrap();
-    // ...
-    let _sunrise_set: SunriseAndSet =  sunrise_and_set::<StdFloatOps>(dt, lat, lon).unwrap();
-    // ...
-}
-```
+- On `std` target builds, the built-in implementation `StdFloatOps` is provided
+for your convenience, gated behind the `std` feature.
+- On `no_std` target builds, you need to provide your own implementation for
+floating point operations, for example using [libm](https://docs.rs/libm/0.2.7/libm/).

--- a/examples/solar_pos.rs
+++ b/examples/solar_pos.rs
@@ -3,39 +3,10 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! This example needs to be run with the `std` feature.
+
 use chrono::{TimeZone, Utc};
-use spa::{solar_position, FloatOps, SolarPos};
-
-// FloatOps for the std environment
-pub struct StdFloatOps;
-
-// FloatOps for the std environment, mapping directly onto f64 operations
-impl FloatOps for StdFloatOps {
-    fn sin(x: f64) -> f64 {
-        x.sin()
-    }
-    fn cos(x: f64) -> f64 {
-        x.cos()
-    }
-    fn tan(x: f64) -> f64 {
-        x.tan()
-    }
-    fn asin(x: f64) -> f64 {
-        x.asin()
-    }
-    fn acos(x: f64) -> f64 {
-        x.acos()
-    }
-    fn atan(x: f64) -> f64 {
-        x.atan()
-    }
-    fn atan2(y: f64, x: f64) -> f64 {
-        y.atan2(x)
-    }
-    fn trunc(x: f64) -> f64 {
-        x.trunc()
-    }
-}
+use spa::{solar_position, SolarPos, StdFloatOps};
 
 // main
 fn main() {

--- a/examples/solar_pos.rs
+++ b/examples/solar_pos.rs
@@ -4,28 +4,45 @@
 // except according to those terms.
 
 use chrono::{TimeZone, Utc};
-use spa::{solar_position, SolarPos, FloatOps};
-
+use spa::{solar_position, FloatOps, SolarPos};
 
 // FloatOps for the std environment
 pub struct StdFloatOps;
 
 // FloatOps for the std environment, mapping directly onto f64 operations
 impl FloatOps for StdFloatOps {
-    fn sin(x: f64) -> f64 { x.sin() }
-    fn cos(x: f64) -> f64 { x.cos() }
-    fn tan(x: f64) -> f64 { x.tan() }
-    fn asin(x: f64) -> f64 { x.asin() }
-    fn acos(x: f64) -> f64 { x.acos() }
-    fn atan(x: f64) -> f64 { x.atan() }
-    fn atan2(y: f64, x: f64) -> f64 { y.atan2(x) }
-    fn trunc(x: f64) -> f64 { x.trunc() }
+    fn sin(x: f64) -> f64 {
+        x.sin()
+    }
+    fn cos(x: f64) -> f64 {
+        x.cos()
+    }
+    fn tan(x: f64) -> f64 {
+        x.tan()
+    }
+    fn asin(x: f64) -> f64 {
+        x.asin()
+    }
+    fn acos(x: f64) -> f64 {
+        x.acos()
+    }
+    fn atan(x: f64) -> f64 {
+        x.atan()
+    }
+    fn atan2(y: f64, x: f64) -> f64 {
+        y.atan2(x)
+    }
+    fn trunc(x: f64) -> f64 {
+        x.trunc()
+    }
 }
 
 // main
 fn main() {
-    let dt = Utc.with_ymd_and_hms(2005, 9, 30, 12, 0, 0)
-        .single().unwrap();
+    let dt = Utc
+        .with_ymd_and_hms(2005, 9, 30, 12, 0, 0)
+        .single()
+        .unwrap();
 
     // geo-pos near Frankfurt/Germany
     let lat = 50.0;

--- a/examples/sunrise_and_set.rs
+++ b/examples/sunrise_and_set.rs
@@ -3,39 +3,10 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! This example needs to be run with the `std` feature.
+
 use chrono::{TimeZone, Utc};
-use spa::{sunrise_and_set, FloatOps, SunriseAndSet};
-
-// FloatOps for the std environment
-pub struct StdFloatOps;
-
-// FloatOps for the std environment, mapping directly onto f64 operations
-impl FloatOps for StdFloatOps {
-    fn sin(x: f64) -> f64 {
-        x.sin()
-    }
-    fn cos(x: f64) -> f64 {
-        x.cos()
-    }
-    fn tan(x: f64) -> f64 {
-        x.tan()
-    }
-    fn asin(x: f64) -> f64 {
-        x.asin()
-    }
-    fn acos(x: f64) -> f64 {
-        x.acos()
-    }
-    fn atan(x: f64) -> f64 {
-        x.atan()
-    }
-    fn atan2(y: f64, x: f64) -> f64 {
-        y.atan2(x)
-    }
-    fn trunc(x: f64) -> f64 {
-        x.trunc()
-    }
-}
+use spa::{sunrise_and_set, StdFloatOps, SunriseAndSet};
 
 fn main() {
     // test-vector from http://lexikon.astronomie.info/zeitgleichung/neu.html

--- a/examples/sunrise_and_set.rs
+++ b/examples/sunrise_and_set.rs
@@ -6,35 +6,52 @@
 use chrono::{TimeZone, Utc};
 use spa::{sunrise_and_set, FloatOps, SunriseAndSet};
 
-
 // FloatOps for the std environment
 pub struct StdFloatOps;
 
 // FloatOps for the std environment, mapping directly onto f64 operations
 impl FloatOps for StdFloatOps {
-    fn sin(x: f64) -> f64 { x.sin() }
-    fn cos(x: f64) -> f64 { x.cos() }
-    fn tan(x: f64) -> f64 { x.tan() }
-    fn asin(x: f64) -> f64 { x.asin() }
-    fn acos(x: f64) -> f64 { x.acos() }
-    fn atan(x: f64) -> f64 { x.atan() }
-    fn atan2(y: f64, x: f64) -> f64 { y.atan2(x) }
-    fn trunc(x: f64) -> f64 { x.trunc() }
+    fn sin(x: f64) -> f64 {
+        x.sin()
+    }
+    fn cos(x: f64) -> f64 {
+        x.cos()
+    }
+    fn tan(x: f64) -> f64 {
+        x.tan()
+    }
+    fn asin(x: f64) -> f64 {
+        x.asin()
+    }
+    fn acos(x: f64) -> f64 {
+        x.acos()
+    }
+    fn atan(x: f64) -> f64 {
+        x.atan()
+    }
+    fn atan2(y: f64, x: f64) -> f64 {
+        y.atan2(x)
+    }
+    fn trunc(x: f64) -> f64 {
+        x.trunc()
+    }
 }
 
 fn main() {
-
     // test-vector from http://lexikon.astronomie.info/zeitgleichung/neu.html
-    let dt = Utc.with_ymd_and_hms(2005, 9, 30, 12, 0, 0)
-        .single().unwrap();
+    let dt = Utc
+        .with_ymd_and_hms(2005, 9, 30, 12, 0, 0)
+        .single()
+        .unwrap();
 
     // geo-pos near Frankfurt/Germany
     let lat = 50.0;
     let lon = 10.0;
 
     match sunrise_and_set::<StdFloatOps>(dt, lat, lon).unwrap() {
-        SunriseAndSet::Daylight(sunrise, sunset) =>
-            println!("Sunrise and set: {} ----> {}", sunrise, sunset),
+        SunriseAndSet::Daylight(sunrise, sunset) => {
+            println!("Sunrise and set: {} ----> {}", sunrise, sunset)
+        }
         SunriseAndSet::PolarDay | SunriseAndSet::PolarNight => panic!(),
     }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+# use default formatter settings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@ impl core::fmt::Display for SpaError {
     }
 }
 
+/// The error conditions
 #[cfg(any(feature = "std", test))]
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum SpaError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub trait FloatOps {
     fn trunc(x: f64) -> f64;
 }
 
-// FloatOps for the std environment, mapping directly onto f64 operations
+/// FloatOps for the std environment, mapping directly onto f64 operations
 #[cfg(any(feature = "std", test))]
 pub enum StdFloatOps {}
 #[cfg(any(feature = "std", test))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! // main
 //! fn main() {
-//!     let datetime = Utc.with_ymd_and_hms(2005, 9, 30, 12, 0, 0)
+//!     let dt = Utc.with_ymd_and_hms(2005, 9, 30, 12, 0, 0)
 //!         .single().unwrap();
 //!
 //!     // geo-pos near Frankfurt/Germany
@@ -48,23 +48,7 @@ const JD2000: f64 = 2451545.0;
 
 /// platform specific floating operations
 ///
-/// For example implement as
-/// ```rust
-/// /// FloatOps type
-/// pub struct StdFloatOps;
-///
-/// /// FloatOps for the std environment, mapping directly onto f64 operations
-/// impl FloatOps for StdFloatOps {
-///     fn sin(x: f64) -> f64 { x.sin() }
-///     fn cos(x: f64) -> f64 { x.cos() }
-///     fn tan(x: f64) -> f64 { x.tan() }
-///     fn asin(x: f64) -> f64 { x.asin() }
-///     fn acos(x: f64) -> f64 { x.acos() }
-///     fn atan(x: f64) -> f64 { x.atan() }
-///     fn atan2(y: f64, x: f64) -> f64 { y.atan2(x) }
-///     fn trunc(x: f64) -> f64 { x.trunc() }
-/// }
-/// ```
+/// For `std` targets, you can use the provided [`StdFloatOps`]
 pub trait FloatOps {
     fn sin(x: f64) -> f64;
     fn cos(x: f64) -> f64;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,6 @@ pub trait FloatOps {
     fn trunc(x: f64) -> f64;
 }
 
-
 /// The sun-rise and sun-set as UTC, otherwise permanent polar-night or polar-day
 #[derive(Debug, Clone)]
 pub enum SunriseAndSet {
@@ -189,7 +188,8 @@ fn in_pi(x: f64) -> f64 {
 /// * `t` - time according to standard equinox J2000.0
 ///
 fn eps(t: f64) -> f64 {
-    return RAD * (23.43929111 + ((-46.8150) * t - 0.00059 * t * t + 0.001813 * t * t * t) / 3600.0);
+    return RAD
+        * (23.43929111 + ((-46.8150) * t - 0.00059 * t * t + 0.001813 * t * t * t) / 3600.0);
 }
 
 /// Calculates equation of time, returning the tuple (delta-ascension, declination)
@@ -303,7 +303,11 @@ pub fn sunrise_and_set<F: FloatOps>(
 ///
 /// Algorithm ported to Rust from [http://www.psa.es/sdg/sunpos.htm](https://web.archive.org/web/20220308165815/http://www.psa.es/sdg/sunpos.htm)
 /// The algorithm is accurate to within 0.5 minutes of arc for the year 1999 and following.
-pub fn solar_position<F: FloatOps>(utc: DateTime<Utc>, lat: f64, lon: f64) -> Result<SolarPos, SpaError> {
+pub fn solar_position<F: FloatOps>(
+    utc: DateTime<Utc>,
+    lat: f64,
+    lon: f64,
+) -> Result<SolarPos, SpaError> {
     if -90.0 > lat || 90.0 < lat || -180.0 > lon || 180.0 < lon {
         return Err(SpaError::BadParam);
     }
@@ -384,16 +388,16 @@ pub fn solar_position<F: FloatOps>(utc: DateTime<Utc>, lat: f64, lon: f64) -> Re
 
 #[cfg(test)]
 mod tests {
-    use chrono::{TimeZone, Timelike, Datelike, Utc};
+    use chrono::{Datelike, TimeZone, Timelike, Utc};
 
-    use super::FloatOps;
     use super::berechne_zeitgleichung;
-    use super::solar_position;
-    use super::sunrise_and_set;
     use super::eps;
     use super::in_pi;
+    use super::solar_position;
+    use super::sunrise_and_set;
     use super::to_julian;
     use super::to_utc;
+    use super::FloatOps;
     use super::SunriseAndSet;
     use super::JD2000;
     use super::PI2;
@@ -406,20 +410,35 @@ mod tests {
     const LAT_DEG: f64 = 48.1;
     const LON_DEG: f64 = 11.6;
 
-
     // FloatOps for the std environment
     pub struct StdFloatOps;
 
     // FloatOps for the std environment, mapping directly onto f64 operations
     impl FloatOps for StdFloatOps {
-        fn sin(x: f64) -> f64 { x.sin() }
-        fn cos(x: f64) -> f64 { x.cos() }
-        fn tan(x: f64) -> f64 { x.tan() }
-        fn asin(x: f64) -> f64 { x.asin() }
-        fn acos(x: f64) -> f64 { x.acos() }
-        fn atan(x: f64) -> f64 { x.atan() }
-        fn atan2(y: f64, x: f64) -> f64 { y.atan2(x) }
-        fn trunc(x: f64) -> f64 { x.trunc() }
+        fn sin(x: f64) -> f64 {
+            x.sin()
+        }
+        fn cos(x: f64) -> f64 {
+            x.cos()
+        }
+        fn tan(x: f64) -> f64 {
+            x.tan()
+        }
+        fn asin(x: f64) -> f64 {
+            x.asin()
+        }
+        fn acos(x: f64) -> f64 {
+            x.acos()
+        }
+        fn atan(x: f64) -> f64 {
+            x.atan()
+        }
+        fn atan2(y: f64, x: f64) -> f64 {
+            y.atan2(x)
+        }
+        fn trunc(x: f64) -> f64 {
+            x.trunc()
+        }
     }
 
     #[test]
@@ -444,10 +463,8 @@ mod tests {
     #[test]
     /// test-vector from [https://de.wikipedia.org/wiki/Sonnenstand](https://web.archive.org/web/20220712235611/https://de.wikipedia.org/wiki/Sonnenstand)
     fn test_julian_day() {
-
         //  6. August 2006 um 6 Uhr ut
-        let dt = Utc.with_ymd_and_hms(2006, 8, 6, 6, 0, 0)
-            .single().unwrap();
+        let dt = Utc.with_ymd_and_hms(2006, 8, 6, 6, 0, 0).single().unwrap();
 
         let jd = to_julian(dt);
         assert_eq!(jd, 2453953.75);
@@ -459,15 +476,16 @@ mod tests {
     #[test]
     /// test-vector from [http://lexikon.astronomie.info/zeitgleichung/neu.html](https://web.archive.org/web/20170812034800/http://lexikon.astronomie.info/zeitgleichung/neu.html)
     fn test_zeitgleichung() {
-
         let exp_jd = 2453644.0;
         let exp_t = 0.057467488021902803;
         let exp_e = 0.40907976105657956;
         let exp_d_ra = 0.18539782794253773;
         let exp_dk = -0.05148602985190724;
 
-        let dt = Utc.with_ymd_and_hms(2005, 9, 30, 12, 0, 0)
-            .single().unwrap();
+        let dt = Utc
+            .with_ymd_and_hms(2005, 9, 30, 12, 0, 0)
+            .single()
+            .unwrap();
 
         let jd = to_julian(dt);
         assert_eq!(exp_jd, jd);
@@ -486,9 +504,10 @@ mod tests {
     #[test]
     /// test-vector from [http://lexikon.astronomie.info/zeitgleichung/neu.html](https://web.archive.org/web/20170812034800/http://lexikon.astronomie.info/zeitgleichung/neu.html)
     fn test_sunrise_and_set() {
-
-        let dt = Utc.with_ymd_and_hms(2005, 9, 30, 12, 0, 0)
-            .single().unwrap();
+        let dt = Utc
+            .with_ymd_and_hms(2005, 9, 30, 12, 0, 0)
+            .single()
+            .unwrap();
 
         // geo-pos near Frankfurt/Germany
         let lat = 50.0;
@@ -518,8 +537,10 @@ mod tests {
     #[test]
     /// test-vector from [http://lexikon.astronomie.info/zeitgleichung/neu.html](https://web.archive.org/web/20170812034800/http://lexikon.astronomie.info/zeitgleichung/neu.html)
     fn test_sunrise_and_set_polarday() {
-        let dt = Utc.with_ymd_and_hms(2005, 6, 30, 12, 0, 0)
-            .single().unwrap();
+        let dt = Utc
+            .with_ymd_and_hms(2005, 6, 30, 12, 0, 0)
+            .single()
+            .unwrap();
 
         // geo-pos in northern polar region
         let lat = 67.4;
@@ -537,8 +558,10 @@ mod tests {
     #[test]
     /// test-vector from [http://lexikon.astronomie.info/zeitgleichung/neu.html](https://web.archive.org/web/20170812034800/http://lexikon.astronomie.info/zeitgleichung/neu.html)
     fn test_sunrise_and_set_polarnight() {
-        let dt = Utc.with_ymd_and_hms(2005, 6, 30, 12, 0, 0)
-            .single().unwrap();
+        let dt = Utc
+            .with_ymd_and_hms(2005, 6, 30, 12, 0, 0)
+            .single()
+            .unwrap();
 
         // geo-pos in southern polar region
         let lat = -68.0;
@@ -559,8 +582,10 @@ mod tests {
         let exp_azimuth = 195.51003782406534;
         let exp_zenith_angle = 54.03653683638118;
 
-        let dt = Utc.with_ymd_and_hms(2005, 9, 30, 12, 0, 0)
-            .single().unwrap();
+        let dt = Utc
+            .with_ymd_and_hms(2005, 9, 30, 12, 0, 0)
+            .single()
+            .unwrap();
 
         // geo-pos near Frankfurt/Germany
         let lat = 50.0;


### PR DESCRIPTION
1. Provide `StdFloatOps` as a builtin, gated behind the `std` feature. So that users don't have to rewrite it.
2. Derive `std::error::Error` on `SpaError`. So that it integrates better with rust's error ecosystem.

I also formatted the code for good measure.