### PR TITLE
Make `chrono` an optional dependency, add `jiff` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,11 @@ thiserror = { version = "1", optional = true }
 
 [dev-dependencies]
 thiserror = "1"
+
+[[example]]
+name = "solar_pos"
+required-features = ["std"]
+
+[[example]]
+name = "sunrise_and_set"
+required-features = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,10 @@ repository = "https://github.com/frehberg/spa-rs"
 default = ["std"]
 std = ["thiserror"]
 chrono = ["dep:chrono"]
+jiff = ["dep:jiff"]
 
 [dependencies]
+jiff = { version = "^0.2", default-features = false, optional = true }
 chrono = { version = "^0.4", default-features = false, optional = true }
 thiserror = { version = "1", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,16 @@ repository = "https://github.com/frehberg/spa-rs"
 [features]
 default = ["std"]
 std = ["thiserror"]
+chrono = ["dep:chrono"]
 
 [dependencies]
-chrono = { version = "^0.4", default-features = false }
+chrono = { version = "^0.4", default-features = false, optional = true }
 thiserror = { version = "1", optional = true }
 
 [dev-dependencies]
 thiserror = "1"
+chrono = { version = "^0.4", default-features = false }
+chrono-tz = { version = "^0.10" }
 
 [[example]]
 name = "solar_pos"
@@ -28,4 +31,4 @@ required-features = ["std"]
 
 [[example]]
 name = "sunrise_and_set"
-required-features = ["std"]
+required-features = ["std", "chrono"]

--- a/examples/solar_pos.rs
+++ b/examples/solar_pos.rs
@@ -5,21 +5,18 @@
 
 //! This example needs to be run with the `std` feature.
 
-use chrono::{TimeZone, Utc};
+use std::time::SystemTime;
+
 use spa::{solar_position, SolarPos, StdFloatOps};
 
 // main
 fn main() {
-    let dt = Utc
-        .with_ymd_and_hms(2005, 9, 30, 12, 0, 0)
-        .single()
-        .unwrap();
-
     // geo-pos near Frankfurt/Germany
     let lat = 50.0;
     let lon = 10.0;
 
-    let solpos: SolarPos = solar_position::<StdFloatOps>(dt, lat, lon).unwrap();
+    let solpos: SolarPos =
+        solar_position::<StdFloatOps>(SystemTime::now().into(), lat, lon).unwrap();
 
     println!("Solar position: {}/{}", solpos.zenith_angle, solpos.azimuth);
 }

--- a/examples/sunrise_and_set.rs
+++ b/examples/sunrise_and_set.rs
@@ -3,15 +3,18 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! This example needs to be run with the `std` feature.
+//! This example needs to be run with the `std` and `chrono` features.
 
-use chrono::{TimeZone, Utc};
+use chrono::{DateTime, NaiveDate, NaiveTime};
 use spa::{sunrise_and_set, StdFloatOps, SunriseAndSet};
 
 fn main() {
     // test-vector from http://lexikon.astronomie.info/zeitgleichung/neu.html
-    let dt = Utc
-        .with_ymd_and_hms(2005, 9, 30, 12, 0, 0)
+    let tz = chrono_tz::Europe::Berlin;
+    let dt = NaiveDate::from_ymd_opt(2005, 9, 30)
+        .unwrap()
+        .and_time(NaiveTime::from_hms_opt(12, 0, 0).unwrap())
+        .and_local_timezone(tz)
         .single()
         .unwrap();
 
@@ -19,8 +22,11 @@ fn main() {
     let lat = 50.0;
     let lon = 10.0;
 
-    match sunrise_and_set::<StdFloatOps>(dt, lat, lon).unwrap() {
+    match sunrise_and_set::<StdFloatOps>(dt.into(), lat, lon).unwrap() {
         SunriseAndSet::Daylight(sunrise, sunset) => {
+            let sunrise = DateTime::from(sunrise).with_timezone(&tz);
+            let sunset = DateTime::from(sunset).with_timezone(&tz);
+
             println!("Sunrise and set: {} ----> {}", sunrise, sunset)
         }
         SunriseAndSet::PolarDay | SunriseAndSet::PolarNight => panic!(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,28 @@ impl From<Timestamp> for chrono::DateTime<chrono::Utc> {
     }
 }
 
+#[cfg(any(feature = "jiff", test))]
+impl From<jiff::Timestamp> for Timestamp {
+    fn from(value: jiff::Timestamp) -> Self {
+        Self {
+            seconds_since_unix_epoch: value.as_second(),
+        }
+    }
+}
+
+#[cfg(any(feature = "jiff", test))]
+impl From<Timestamp> for jiff::Timestamp {
+    fn from(value: Timestamp) -> Self {
+        if value.seconds_since_unix_epoch > jiff::Timestamp::MAX.as_second() {
+            jiff::Timestamp::MAX
+        } else if value.seconds_since_unix_epoch < jiff::Timestamp::MIN.as_second() {
+            jiff::Timestamp::MIN
+        } else {
+            jiff::Timestamp::from_second(value.seconds_since_unix_epoch).unwrap()
+        }
+    }
+}
+
 #[cfg(any(feature = "std", test))]
 impl From<std::time::SystemTime> for Timestamp {
     fn from(value: std::time::SystemTime) -> Self {


### PR DESCRIPTION
This replaces the `chrono::DateTime<Utc>` timestamp type that is used on the API by a `Timestamp` struct, which has conversion methods to `chrono::DateTime<Utc>`, `std::time::SystemTime`, and `jiff::Timestamp`.